### PR TITLE
Issues/56 connection test on processes deployed

### DIFF
--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/DataTransferProcessPluginDefinition.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/DataTransferProcessPluginDefinition.java
@@ -13,9 +13,12 @@ import org.highmed.dsf.fhir.resources.NamingSystemResource;
 import org.highmed.dsf.fhir.resources.ResourceProvider;
 import org.highmed.dsf.fhir.resources.StructureDefinitionResource;
 import org.highmed.dsf.fhir.resources.ValueSetResource;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.PropertyResolver;
 
 import ca.uhn.fhir.context.FhirContext;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.FttpClientFactory;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClientFactory;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.spring.config.TransferDataConfig;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.spring.config.TransferDataSerializerConfig;
 
@@ -86,5 +89,21 @@ public class DataTransferProcessPluginDefinition implements ProcessPluginDefinit
 
 		return ResourceProvider.read(VERSION, () -> fhirContext.newXmlParser().setStripVersionsFromReferences(false),
 				classLoader, propertyResolver, resourcesByProcessKeyAndVersion);
+	}
+
+	@Override
+	public void onProcessesDeployed(ApplicationContext pluginApplicationContext, List<String> activeProcesses)
+	{
+		if (activeProcesses.contains("wwwnetzwerk-universitaetsmedizinde_dataSend")
+				|| activeProcesses.contains("wwwnetzwerk-universitaetsmedizinde_dataReceive"))
+		{
+			pluginApplicationContext.getBean(GeccoClientFactory.class).testConnection();
+		}
+
+		if (activeProcesses.contains("wwwnetzwerk-universitaetsmedizinde_dataSend")
+				|| activeProcesses.contains("wwwnetzwerk-universitaetsmedizinde_dataTranslate"))
+		{
+			pluginApplicationContext.getBean(FttpClientFactory.class).testConnection();
+		}
 	}
 }

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/FttpClientFactory.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/FttpClientFactory.java
@@ -22,8 +22,6 @@ import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.pkcs.PKCSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
 
 import de.rwh.utils.crypto.CertificateHelper;
 import de.rwh.utils.crypto.io.CertificateReader;
@@ -129,8 +127,7 @@ public class FttpClientFactory
 		this.hapiClientVerbose = hapiClientVerbose;
 	}
 
-	@EventListener({ ContextRefreshedEvent.class })
-	public void onContextRefreshedEvent(ContextRefreshedEvent event)
+	public void testConnection()
 	{
 		try
 		{

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/GeccoClientFactory.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/GeccoClientFactory.java
@@ -14,8 +14,6 @@ import java.util.UUID;
 import org.bouncycastle.pkcs.PKCSException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
@@ -143,8 +141,7 @@ public class GeccoClientFactory
 		this.useChainedParameterNotLogicalReference = useChainedParameterNotLogicalReference;
 	}
 
-	@EventListener({ ContextRefreshedEvent.class })
-	public void onContextRefreshedEvent(ContextRefreshedEvent event)
+	public void testConnection()
 	{
 		try
 		{

--- a/codex-processes-ap1-docker-test-setup/docker-compose.yml
+++ b/codex-processes-ap1-docker-test-setup/docker-compose.yml
@@ -66,7 +66,7 @@ services:
 
 
   dic-fhir:
-    image: ghcr.io/highmed/fhir:0.5.4
+    image: ghcr.io/highmed/fhir:0.6.0
     restart: on-failure
     ports:
       - 127.0.0.1:5000:5000
@@ -113,7 +113,7 @@ services:
       - db
       - proxy
   dic-bpe:
-    image: ghcr.io/highmed/bpe:0.5.4
+    image: ghcr.io/highmed/bpe:0.6.0
     restart: on-failure
     ports:
       - 127.0.0.1:5003:5003
@@ -194,7 +194,7 @@ services:
 
 
   gth-fhir:
-    image: ghcr.io/highmed/fhir:0.5.4
+    image: ghcr.io/highmed/fhir:0.6.0
     restart: on-failure
     ports:
       - 127.0.0.1:5001:5001
@@ -241,7 +241,7 @@ services:
       - db
       - proxy
   gth-bpe:
-    image: ghcr.io/highmed/bpe:0.5.4
+    image: ghcr.io/highmed/bpe:0.6.0
     restart: on-failure
     ports:
       - 127.0.0.1:5004:5004
@@ -298,7 +298,7 @@ services:
 
 
   crr-fhir:
-    image: ghcr.io/highmed/fhir:0.5.4
+    image: ghcr.io/highmed/fhir:0.6.0
     restart: on-failure
     ports:
       - 127.0.0.1:5002:5002
@@ -345,7 +345,7 @@ services:
       - db
       - proxy
   crr-bpe:
-    image: ghcr.io/highmed/bpe:0.5.4
+    image: ghcr.io/highmed/bpe:0.6.0
     restart: on-failure
     ports:
       - 127.0.0.1:5005:5005

--- a/codex-processes-ap1-docker-test-setup/docker-compose.yml
+++ b/codex-processes-ap1-docker-test-setup/docker-compose.yml
@@ -66,7 +66,7 @@ services:
 
 
   dic-fhir:
-    image: ghcr.io/highmed/fhir:0.6.0
+    image: ghcr.io/highmed/fhir:0.6.0-RC3
     restart: on-failure
     ports:
       - 127.0.0.1:5000:5000
@@ -113,7 +113,7 @@ services:
       - db
       - proxy
   dic-bpe:
-    image: ghcr.io/highmed/bpe:0.6.0
+    image: ghcr.io/highmed/bpe:0.6.0-RC3
     restart: on-failure
     ports:
       - 127.0.0.1:5003:5003
@@ -194,7 +194,7 @@ services:
 
 
   gth-fhir:
-    image: ghcr.io/highmed/fhir:0.6.0
+    image: ghcr.io/highmed/fhir:0.6.0-RC3
     restart: on-failure
     ports:
       - 127.0.0.1:5001:5001
@@ -241,7 +241,7 @@ services:
       - db
       - proxy
   gth-bpe:
-    image: ghcr.io/highmed/bpe:0.6.0
+    image: ghcr.io/highmed/bpe:0.6.0-RC3
     restart: on-failure
     ports:
       - 127.0.0.1:5004:5004
@@ -298,7 +298,7 @@ services:
 
 
   crr-fhir:
-    image: ghcr.io/highmed/fhir:0.6.0
+    image: ghcr.io/highmed/fhir:0.6.0-RC3
     restart: on-failure
     ports:
       - 127.0.0.1:5002:5002
@@ -345,7 +345,7 @@ services:
       - db
       - proxy
   crr-bpe:
-    image: ghcr.io/highmed/bpe:0.6.0
+    image: ghcr.io/highmed/bpe:0.6.0-RC3
     restart: on-failure
     ports:
       - 127.0.0.1:5005:5005

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 		<main.basedir>${project.basedir}</main.basedir>
 		<hapi.version>5.1.0</hapi.version>
-		<dsf.version>0.5.4</dsf.version>
+		<dsf.version>0.6.0-SNAPSHOT</dsf.version>
 	</properties>
 
 	<description>Business processes for the NUM CODEX project (AP1) as plugins for the HiGHmed Data Sharing Framework.</description>


### PR DESCRIPTION
The conenction test to the GECCO FHIR Server is only performed if process `wwwnetzwerk-universitaetsmedizinde_dataSend` or `wwwnetzwerk-universitaetsmedizinde_dataReceive` are active. Likewise the connection test to the fTTP is only performed if process `wwwnetzwerk-universitaetsmedizinde_dataSend` or `wwwnetzwerk-universitaetsmedizinde_dataTranslate` are active.

This PR can be merged if highmed/highmed-dsf#261 is closed and released.

closes #56 