### PR TITLE
search bundle urls now encoded, reworks param replacement, closes #53

### DIFF
--- a/codex-process-data-transfer/pom.xml
+++ b/codex-process-data-transfer/pom.xml
@@ -26,6 +26,11 @@
 			<artifactId>hapi-fhir-client</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+    		<groupId>org.springframework</groupId>
+    		<artifactId>spring-web</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>de.hs-heilbronn.mi</groupId>
@@ -37,6 +42,11 @@
 			<artifactId>dsf-fhir-validation</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/AbstractFhirClientTest.java
+++ b/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/AbstractFhirClientTest.java
@@ -1,0 +1,168 @@
+package de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.fhir;
+
+import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.NAMING_SYSTEM_NUM_CODEX_DIC_PSEUDONYM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.when;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.domain.DateWithPrecision;
+
+public class AbstractFhirClientTest
+{
+	private static final Logger logger = LoggerFactory.getLogger(AbstractFhirClientTest.class);
+
+	@Test
+	public void testSetSearchBundleWithExportTo() throws Exception
+	{
+		FhirContext fhirContext = FhirContext.forR4();
+		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		when(geccoClient.getSearchBundleOverride())
+				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
+		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
+		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
+				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+
+		Date exportTo = new Date();
+
+		Bundle bundle = client.getSearchBundle(null, exportTo);
+		assertNotNull(bundle);
+		assertTrue(bundle.hasEntry());
+		assertNotNull(bundle.getEntry());
+		assertEquals(64, bundle.getEntry().size());
+
+		logger.debug("Search Bundle after replacement: {}", fhirContext.newJsonParser().encodeResourceToString(bundle));
+
+		SimpleDateFormat timeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+		String exportToString = timeFormat.format(exportTo).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+
+		String expectedUrl = "Condition?_profile=https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/cardiovascular-diseases&_include=Condition%3Apatient"
+				+ "&_lastUpdated=lt" + exportToString;
+
+		long entriesWithExpectedUrl = bundle.getEntry().stream().filter(e -> e.hasRequest())
+				.filter(e -> e.getRequest().hasUrl()).filter(e -> e.getRequest().getUrl().equals(expectedUrl)).count();
+		assertEquals(1, entriesWithExpectedUrl);
+	}
+
+	@Test
+	public void testSetSearchBundleWithExportFromAndExportTo() throws Exception
+	{
+		FhirContext fhirContext = FhirContext.forR4();
+		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		when(geccoClient.getSearchBundleOverride())
+				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
+		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
+		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
+				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+
+		DateWithPrecision exportFrom = new DateWithPrecision(new Date(), TemporalPrecisionEnum.MILLI);
+		Date exportTo = new Date();
+
+		Bundle bundle = client.getSearchBundle(exportFrom, exportTo);
+		assertNotNull(bundle);
+		assertTrue(bundle.hasEntry());
+		assertNotNull(bundle.getEntry());
+		assertEquals(64, bundle.getEntry().size());
+
+		logger.debug("Search Bundle after replacement: {}", fhirContext.newJsonParser().encodeResourceToString(bundle));
+
+		SimpleDateFormat timeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+		String exportFromString = timeFormat.format(exportFrom).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+		String exportToString = timeFormat.format(exportTo).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+
+		String expectedUrl = "Condition?_profile=https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/cardiovascular-diseases&_include=Condition%3Apatient"
+				+ "&_lastUpdated=lt" + exportToString + "&_lastUpdated=ge" + exportFromString;
+
+		long entriesWithExpectedUrl = bundle.getEntry().stream().filter(e -> e.hasRequest())
+				.filter(e -> e.getRequest().hasUrl()).filter(e -> e.getRequest().getUrl().equals(expectedUrl)).count();
+		assertEquals(1, entriesWithExpectedUrl);
+	}
+
+	@Test
+	public void testSetSearchBundleWithPatientIdAndExportFromAndExportTo() throws Exception
+	{
+		FhirContext fhirContext = FhirContext.forR4();
+		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		when(geccoClient.getSearchBundleOverride())
+				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
+		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
+		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
+				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+
+		String patientId = "some-patient-id";
+		DateWithPrecision exportFrom = new DateWithPrecision(new Date(), TemporalPrecisionEnum.MILLI);
+		Date exportTo = new Date();
+
+		Bundle bundle = client.getSearchBundleWithPatientId(patientId, exportFrom, exportTo);
+		assertNotNull(bundle);
+		assertTrue(bundle.hasEntry());
+		assertNotNull(bundle.getEntry());
+		assertEquals(63, bundle.getEntry().size());
+
+		logger.debug("Search Bundle after replacement: {}", fhirContext.newJsonParser().encodeResourceToString(bundle));
+
+		SimpleDateFormat timeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+		String exportFromString = timeFormat.format(exportFrom).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+		String exportToString = timeFormat.format(exportTo).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+
+		String expectedUrl = "Condition?_profile=https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/cardiovascular-diseases"
+				+ "&patient=" + patientId + "&_lastUpdated=lt" + exportToString + "&_lastUpdated=ge" + exportFromString;
+
+		long entriesWithExpectedUrl = bundle.getEntry().stream().filter(e -> e.hasRequest())
+				.filter(e -> e.getRequest().hasUrl()).filter(e -> e.getRequest().getUrl().equals(expectedUrl)).count();
+		assertEquals(1, entriesWithExpectedUrl);
+	}
+
+	@Test
+	public void testSetSearchBundleWithPseudonymIdAndExportFromAndExportTo() throws Exception
+	{
+		FhirContext fhirContext = FhirContext.forR4();
+		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		when(geccoClient.getSearchBundleOverride())
+				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
+		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
+		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
+				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+
+		String pseudonym = "some-pseudonym";
+		DateWithPrecision exportFrom = new DateWithPrecision(new Date(), TemporalPrecisionEnum.MILLI);
+		Date exportTo = new Date();
+
+		Bundle bundle = client.getSearchBundleWithPseudonym(pseudonym, exportFrom, exportTo);
+		assertNotNull(bundle);
+		assertTrue(bundle.hasEntry());
+		assertNotNull(bundle.getEntry());
+		assertEquals(64, bundle.getEntry().size());
+
+		logger.debug("Search Bundle after replacement: {}", fhirContext.newJsonParser().encodeResourceToString(bundle));
+
+		String namingSystemString = URLEncoder.encode(NAMING_SYSTEM_NUM_CODEX_DIC_PSEUDONYM, StandardCharsets.UTF_8);
+		SimpleDateFormat timeFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+		String exportFromString = timeFormat.format(exportFrom).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+		String exportToString = timeFormat.format(exportTo).replaceAll("\\+", "%2B").replaceAll(":", "%3A");
+
+		String expectedUrl = "Condition?_profile=https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/cardiovascular-diseases"
+				+ "&patient:identifier=" + namingSystemString + "%7C" + pseudonym + "&_lastUpdated=lt" + exportToString
+				+ "&_lastUpdated=ge" + exportFromString;
+
+		long entriesWithExpectedUrl = bundle.getEntry().stream().filter(e -> e.hasRequest())
+				.filter(e -> e.getRequest().hasUrl()).filter(e -> e.getRequest().getUrl().equals(expectedUrl)).count();
+		assertEquals(1, entriesWithExpectedUrl);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
 				<artifactId>jackson-annotations</artifactId>
 				<version>2.12.0</version>
 			</dependency>
+			<dependency>
+    			<groupId>org.springframework</groupId>
+    			<artifactId>spring-web</artifactId>
+				<version>5.3.19</version>
+			</dependency>
 
 			<!-- testing -->
 			<dependency>
@@ -126,8 +131,12 @@
 				<groupId>org.highmed.dsf</groupId>
 				<artifactId>dsf-bpe-process-base</artifactId>
 				<version>${dsf.version}</version>
-				<scope>test</scope>
 				<type>test-jar</type>
+			</dependency>
+			<dependency>
+			    <groupId>org.mockito</groupId>
+			    <artifactId>mockito-core</artifactId>
+			    <version>4.5.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Search bundle urls are now "url encoded" based uri templates from the spring framework. Adds some test cases to validate search bundle creation and query parameter replacement.

closes #53