### PR TITLE
Issues/81 bundle logging

### DIFF
--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/DataTransferProcessPluginDefinition.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/DataTransferProcessPluginDefinition.java
@@ -36,8 +36,8 @@ public class DataTransferProcessPluginDefinition implements ProcessPluginDefinit
 {
 	private static final Logger logger = LoggerFactory.getLogger(DataTransferProcessPluginDefinition.class);
 
-	public static final String VERSION = "0.5.1";
-	public static final LocalDate DATE = LocalDate.of(2022, 6, 25);
+	public static final String VERSION = "0.6.0";
+	public static final LocalDate DATE = LocalDate.of(2022, 7, 12);
 
 	@Override
 	public String getName()

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/GeccoClientFactory.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/GeccoClientFactory.java
@@ -19,6 +19,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.fhir.GeccoFhirClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.fhir.GeccoFhirClientStub;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 import de.rwh.utils.crypto.CertificateHelper;
 import de.rwh.utils.crypto.io.CertificateReader;
 import de.rwh.utils.crypto.io.PemIo;
@@ -31,11 +32,13 @@ public class GeccoClientFactory
 	{
 		final FhirContext fhirContext;
 		final String localIdentifierValue;
+		final DataLogger dataLogger;
 
-		GeccoClientStub(FhirContext fhirContext, String localIdentifierValue)
+		GeccoClientStub(FhirContext fhirContext, String localIdentifierValue, DataLogger dataLogger)
 		{
 			this.fhirContext = fhirContext;
 			this.localIdentifierValue = localIdentifierValue;
+			this.dataLogger = dataLogger;
 		}
 
 		@Override
@@ -59,7 +62,7 @@ public class GeccoClientFactory
 		@Override
 		public GeccoFhirClient getFhirClient()
 		{
-			return new GeccoFhirClientStub(this);
+			return new GeccoFhirClientStub(this, dataLogger);
 		}
 
 		@Override
@@ -113,14 +116,16 @@ public class GeccoClientFactory
 	private final Class<GeccoFhirClient> geccoFhirClientClass;
 	private final boolean useChainedParameterNotLogicalReference;
 
+	private final DataLogger dataLogger;
+
 	public GeccoClientFactory(Path trustStorePath, Path certificatePath, Path privateKeyPath, char[] privateKeyPassword,
 			int connectTimeout, int socketTimeout, int connectionRequestTimeout, String geccoServerBase,
 			String geccoServerBasicAuthUsername, String geccoServerBasicAuthPassword, String geccoServerBearerToken,
 			String proxyUrl, String proxyUsername, String proxyPassword, boolean hapiClientVerbose,
 			FhirContext fhirContext, Path searchBundleOverride, String localIdentifierValue,
-			Class<GeccoFhirClient> geccoFhirClientClass, boolean useChainedParameterNotLogicalReference)
+			Class<GeccoFhirClient> geccoFhirClientClass, boolean useChainedParameterNotLogicalReference,
+			DataLogger dataLogger)
 	{
-		super();
 		this.trustStorePath = trustStorePath;
 		this.certificatePath = certificatePath;
 		this.privateKeyPath = privateKeyPath;
@@ -145,6 +150,8 @@ public class GeccoClientFactory
 		this.localIdentifierValue = localIdentifierValue;
 		this.geccoFhirClientClass = geccoFhirClientClass;
 		this.useChainedParameterNotLogicalReference = useChainedParameterNotLogicalReference;
+
+		this.dataLogger = dataLogger;
 	}
 
 	public String getServerBase()
@@ -177,7 +184,7 @@ public class GeccoClientFactory
 		if (configured())
 			return createGeccoClient();
 		else
-			return new GeccoClientStub(fhirContext, localIdentifierValue);
+			return new GeccoClientStub(fhirContext, localIdentifierValue, dataLogger);
 	}
 
 	private boolean configured()
@@ -208,7 +215,7 @@ public class GeccoClientFactory
 				connectionRequestTimeout, geccoServerBasicAuthUsername, geccoServerBasicAuthPassword,
 				geccoServerBearerToken, geccoServerBase, proxyUrl, proxyUsername, proxyPassword, hapiClientVerbose,
 				fhirContext, searchBundleOverride, localIdentifierValue, geccoFhirClientClass,
-				useChainedParameterNotLogicalReference);
+				useChainedParameterNotLogicalReference, dataLogger);
 	}
 
 	private KeyStore readTrustStore(Path trustPath)

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/GeccoClientImpl.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/GeccoClientImpl.java
@@ -19,6 +19,7 @@ import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.fhir.GeccoFhirClient;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 
 public class GeccoClientImpl implements GeccoClient
 {
@@ -40,12 +41,14 @@ public class GeccoClientImpl implements GeccoClient
 	private final Class<GeccoFhirClient> geccoFhirClientClass;
 	private final boolean useChainedParameterNotLogicalReference;
 
+	private final DataLogger dataLogger;
+
 	public GeccoClientImpl(KeyStore trustStore, KeyStore keyStore, char[] keyStorePassword, int connectTimeout,
 			int socketTimeout, int connectionRequestTimeout, String geccoServerBasicAuthUsername,
 			String geccoServerBasicAuthPassword, String geccoServerBearerToken, String geccoServerBase, String proxyUrl,
 			String proxyUsername, String proxyPassword, boolean hapiClientVerbose, FhirContext fhirContext,
 			Path searchBundleOverride, String localIdentifierValue, Class<GeccoFhirClient> geccoFhirClientClass,
-			boolean useChainedParameterNotLogicalReference)
+			boolean useChainedParameterNotLogicalReference, DataLogger dataLogger)
 	{
 		clientFactory = createClientFactory(trustStore, keyStore, keyStorePassword, connectTimeout, socketTimeout,
 				connectionRequestTimeout);
@@ -65,6 +68,8 @@ public class GeccoClientImpl implements GeccoClient
 		this.localIdentifierValue = localIdentifierValue;
 		this.geccoFhirClientClass = geccoFhirClientClass;
 		this.useChainedParameterNotLogicalReference = useChainedParameterNotLogicalReference;
+
+		this.dataLogger = dataLogger;
 	}
 
 	private void configureProxy(IRestfulClientFactory clientFactory, String proxyUrl, String proxyUsername,
@@ -154,9 +159,10 @@ public class GeccoClientImpl implements GeccoClient
 	{
 		try
 		{
-			Constructor<GeccoFhirClient> constructor = geccoFhirClientClass.getConstructor(GeccoClient.class);
+			Constructor<GeccoFhirClient> constructor = geccoFhirClientClass.getConstructor(GeccoClient.class,
+					DataLogger.class);
 
-			return constructor.newInstance(this);
+			return constructor.newInstance(this, dataLogger);
 		}
 		catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
 				| IllegalArgumentException | InvocationTargetException e)

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/FhirBridgeClient.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/FhirBridgeClient.java
@@ -30,6 +30,7 @@ import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.OutcomeLogger;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 
 public class FhirBridgeClient extends AbstractComplexFhirClient
 {
@@ -41,10 +42,12 @@ public class FhirBridgeClient extends AbstractComplexFhirClient
 	/**
 	 * @param geccoClient
 	 *            not <code>null</code>
+	 * @param dataLogger
+	 *            not <code>null</code>
 	 */
-	public FhirBridgeClient(GeccoClient geccoClient)
+	public FhirBridgeClient(GeccoClient geccoClient, DataLogger dataLogger)
 	{
-		super(geccoClient);
+		super(geccoClient, dataLogger);
 	}
 
 	@Override
@@ -259,9 +262,8 @@ public class FhirBridgeClient extends AbstractComplexFhirClient
 			Bundle resultBundle = geccoClient.getGenericFhirClient().search().byUrl(url).sort()
 					.descending("_lastUpdated").count(1).returnBundle(Bundle.class).execute();
 
-			if (logger.isDebugEnabled())
-				logger.debug("{} search-bundle result: {}", resourceType.getAnnotation(ResourceDef.class).name(),
-						geccoClient.getFhirContext().newJsonParser().encodeResourceToString(resultBundle));
+			dataLogger.logData(resourceType.getAnnotation(ResourceDef.class).name() + " search-bundle result: {}",
+					resultBundle);
 
 			if (resultBundle.getTotal() > 0)
 			{

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/GeccoFhirClientStub.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/GeccoFhirClientStub.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.domain.DateWithPrecision;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.variables.PatientReference;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.variables.PatientReferenceList;
 
@@ -35,11 +36,13 @@ public final class GeccoFhirClientStub implements GeccoFhirClient
 	private static final String patient = "{\"resourceType\":\"Patient\",\"meta\":{\"profile\":[\"https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/Patient\"]},\"extension\":[{\"url\":\"https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/ethnic-group\",\"valueCoding\":{\"system\":\"http://snomed.info/sct\",\"code\":\"186019001\",\"display\":\"Other ethnic, mixed origin\"}},{\"url\":\"https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/age\",\"extension\":[{\"url\":\"dateTimeOfDocumentation\",\"valueDateTime\":\"2020-10-01\"},{\"url\":\"age\",\"valueAge\":{\"value\":67,\"unit\":\"years\",\"system\":\"http://unitsofmeasure.org\",\"code\":\"a\"}}]}],\"birthDate\":\"1953-09-30\"}";
 	private static final String observation = "{\"resourceType\":\"Observation\",\"meta\":{\"profile\":[\"https://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/sars-cov-2-rt-pcr\"]},\"identifier\":[{\"type\":{\"coding\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/v2-0203\",\"code\":\"OBI\"}]}}],\"status\":\"final\",\"category\":[{\"coding\":[{\"system\":\"http://loinc.org\",\"code\":\"26436-6\"},{\"system\":\"http://terminology.hl7.org/CodeSystem/observation-category\",\"code\":\"laboratory\"}]}],\"code\":{\"coding\":[{\"system\":\"http://loinc.org\",\"code\":\"94500-6\",\"display\":\"SARS-CoV-2 (COVID-19) RNA [Presence] in Respiratory specimen by NAA with probe detection\"}],\"text\":\"SARS-CoV-2-RNA (PCR)\"},\"effectiveDateTime\":\"2020-11-10T15:50:41.000+01:00\",\"valueCodeableConcept\":{\"coding\":[{\"system\":\"http://snomed.info/sct\",\"code\":\"260373001\",\"display\":\"Detected (qualifier value)\"}],\"text\":\"SARS-CoV-2-RNA positiv\"}}";
 
-	private GeccoClient geccoClient;
+	private final GeccoClient geccoClient;
+	private final DataLogger dataLogger;
 
-	public GeccoFhirClientStub(GeccoClient geccoClient)
+	public GeccoFhirClientStub(GeccoClient geccoClient, DataLogger dataLogger)
 	{
 		this.geccoClient = geccoClient;
+		this.dataLogger = dataLogger;
 	}
 
 	@Override
@@ -48,9 +51,7 @@ public final class GeccoFhirClientStub implements GeccoFhirClient
 		logger.warn("Ignoring bundle with {} {}", bundle.getEntry().size(),
 				bundle.getEntry().size() != 1 ? "entries" : "entry");
 
-		if (logger.isDebugEnabled())
-			logger.debug("Ignored bundle: {}",
-					geccoClient.getFhirContext().newJsonParser().encodeResourceToString(bundle));
+		dataLogger.logData("Ignored bundle", bundle);
 	}
 
 	@Override

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/HapiClient.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/HapiClient.java
@@ -13,18 +13,21 @@ import org.slf4j.LoggerFactory;
 import ca.uhn.fhir.rest.api.Constants;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 
 public class HapiClient extends AbstractComplexFhirClient
 {
-	static final Logger logger = LoggerFactory.getLogger(HapiClient.class);
+	private static final Logger logger = LoggerFactory.getLogger(HapiClient.class);
 
 	/**
 	 * @param geccoClient
 	 *            not <code>null</code>
+	 * @param dataLogger
+	 *            not <code>null</code>
 	 */
-	public HapiClient(GeccoClient geccoClient)
+	public HapiClient(GeccoClient geccoClient, DataLogger dataLogger)
 	{
-		super(geccoClient);
+		super(geccoClient, dataLogger);
 	}
 
 	@Override
@@ -81,9 +84,7 @@ public class HapiClient extends AbstractComplexFhirClient
 			});
 		}
 
-		if (logger.isDebugEnabled())
-			logger.debug("Modified bundle: {}",
-					geccoClient.getFhirContext().newJsonParser().encodeResourceToString(bundle));
+		dataLogger.logData("Modified bundle", bundle);
 	}
 
 	private void modifyBundleWithPatientId(Bundle bundle, String pseudonym, String patientId)

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/SimpleFhirClient.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/SimpleFhirClient.java
@@ -6,24 +6,23 @@ import java.util.stream.Stream;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.DomainResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import ca.uhn.fhir.rest.api.Constants;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.domain.DateWithPrecision;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 
 public class SimpleFhirClient extends AbstractFhirClient
 {
-	private static final Logger logger = LoggerFactory.getLogger(SimpleFhirClient.class);
-
 	/**
 	 * @param geccoClient
 	 *            not <code>null</code>
+	 * @param dataLogger
+	 *            not <code>null</code>
 	 */
-	public SimpleFhirClient(GeccoClient geccoClient)
+	public SimpleFhirClient(GeccoClient geccoClient, DataLogger dataLogger)
 	{
-		super(geccoClient);
+		super(geccoClient, dataLogger);
 	}
 
 	@Override
@@ -38,16 +37,12 @@ public class SimpleFhirClient extends AbstractFhirClient
 	{
 		Bundle searchBundle = getSearchBundleWithPseudonym(pseudonym, exportFrom, exportTo);
 
-		if (logger.isDebugEnabled())
-			logger.debug("Executing Search-Bundle: {}",
-					geccoClient.getFhirContext().newJsonParser().encodeResourceToString(searchBundle));
+		dataLogger.logData("Executing Search-Bundle", searchBundle);
 
 		Bundle resultBundle = geccoClient.getGenericFhirClient().transaction().withBundle(searchBundle)
 				.withAdditionalHeader(Constants.HEADER_PREFER, "handling=strict").execute();
 
-		if (logger.isDebugEnabled())
-			logger.debug("Search-Bundle result: {}",
-					geccoClient.getFhirContext().newJsonParser().encodeResourceToString(resultBundle));
+		dataLogger.logData("Search-Bundle result", resultBundle);
 
 		return distinctById(resultBundle.getEntry().stream().filter(BundleEntryComponent::hasResource)
 				.map(BundleEntryComponent::getResource).filter(r -> r instanceof Bundle).map(r -> (Bundle) r)

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/logging/DataLogger.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/logging/DataLogger.java
@@ -1,0 +1,32 @@
+package de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging;
+
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public class DataLogger
+{
+	private static final Logger logger = LoggerFactory.getLogger(DataLogger.class);
+
+	private final boolean enabled;
+	private final FhirContext fhirContext;
+
+	public DataLogger(boolean enabled, FhirContext fhirContext)
+	{
+		this.enabled = enabled;
+		this.fhirContext = fhirContext;
+	}
+
+	public void logData(String logMessage, Resource resource)
+	{
+		if (enabled)
+			logger.debug("{}: {}", logMessage, asString(resource));
+	}
+
+	private String asString(Resource resource)
+	{
+		return fhirContext.newJsonParser().encodeResourceToString(resource);
+	}
+}

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/receive/InsertDataIntoCodex.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/receive/InsertDataIntoCodex.java
@@ -16,9 +16,9 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.uhn.fhir.context.FhirContext;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClientFactory;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.fhir.ValidationException;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.ContinueStatus;
 
 public class InsertDataIntoCodex extends AbstractServiceDelegate
@@ -26,15 +26,15 @@ public class InsertDataIntoCodex extends AbstractServiceDelegate
 	private static final Logger logger = LoggerFactory.getLogger(InsertDataIntoCodex.class);
 
 	private final GeccoClientFactory geccoClientFactory;
-	private final FhirContext fhirContext;
+	private final DataLogger dataLogger;
 
 	public InsertDataIntoCodex(FhirWebserviceClientProvider clientProvider, TaskHelper taskHelper,
-			ReadAccessHelper readAccessHelper, FhirContext fhirContext, GeccoClientFactory geccoClientFactory)
+			ReadAccessHelper readAccessHelper, GeccoClientFactory geccoClientFactory, DataLogger dataLogger)
 	{
 		super(clientProvider, taskHelper, readAccessHelper);
-		this.fhirContext = fhirContext;
 
 		this.geccoClientFactory = geccoClientFactory;
+		this.dataLogger = dataLogger;
 	}
 
 	@Override
@@ -42,8 +42,8 @@ public class InsertDataIntoCodex extends AbstractServiceDelegate
 	{
 		super.afterPropertiesSet();
 
-		Objects.requireNonNull(fhirContext, "fhirContext");
 		Objects.requireNonNull(geccoClientFactory, "geccoClientFactory");
+		Objects.requireNonNull(dataLogger, "dataLogger");
 	}
 
 	@Override
@@ -56,8 +56,7 @@ public class InsertDataIntoCodex extends AbstractServiceDelegate
 			try
 			{
 				logger.info("Executing bundle against FHIR store ...");
-				if (logger.isDebugEnabled())
-					logger.debug("Received bundle: {}", fhirContext.newJsonParser().encodeResourceToString(bundle));
+				dataLogger.logData("Received bundle", bundle);
 
 				geccoClientFactory.getGeccoClient().getFhirClient().storeBundle(bundle);
 

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/ReceiveConfig.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/ReceiveConfig.java
@@ -43,8 +43,8 @@ public class ReceiveConfig
 	public InsertDataIntoCodex insertDataIntoCodex()
 	{
 		return new InsertDataIntoCodex(transferDataConfig.fhirClientProvider(), transferDataConfig.taskHelper(),
-				transferDataConfig.readAccessHelper(), transferDataConfig.fhirContext(),
-				transferDataConfig.geccoClientFactory());
+				transferDataConfig.readAccessHelper(), transferDataConfig.geccoClientFactory(),
+				transferDataConfig.dataLogger());
 	}
 
 	@Bean

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/SendConfig.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/SendConfig.java
@@ -70,8 +70,8 @@ public class SendConfig
 	public ReadData readData()
 	{
 		return new ReadData(transferDataConfig.fhirClientProvider(), transferDataConfig.taskHelper(),
-				transferDataConfig.readAccessHelper(), transferDataConfig.fhirContext(),
-				transferDataConfig.geccoClientFactory());
+				transferDataConfig.readAccessHelper(), transferDataConfig.geccoClientFactory(),
+				transferDataConfig.dataLogger());
 	}
 
 	@Bean

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/TransferDataConfig.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/TransferDataConfig.java
@@ -25,6 +25,7 @@ import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.crypto.Crr
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.crypto.CrrKeyProviderImpl;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.error.ErrorInputParameterGenerator;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.error.ErrorOutputParameterGenerator;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.ErrorLogger;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.validation.BundleValidatorFactory;
 
@@ -143,6 +144,12 @@ public class TransferDataConfig
 	@ProcessDocumentation(description = "To enable the use of logical references instead of chained parameters (`patient:identifier` instead of `patient.identifier`) while searching for Patients in the GECCO FHIR server set to `true`", processNames = "wwwnetzwerk-universitaetsmedizinde_dataReceive")
 	@Value("${de.netzwerk.universitaetsmedizin.codex.gecco.server.use.chained.parameter.not.logical.reference:true}")
 	private boolean fhirStoreUseChainedParameterNotLogicalReference;
+
+	@ProcessDocumentation(description = "To enable debug logging of search, result and transfer bundles set to `true`", processNames = {
+			"wwwnetzwerk-universitaetsmedizinde_dataTrigger", "wwwnetzwerk-universitaetsmedizinde_dataSend",
+			"wwwnetzwerk-universitaetsmedizinde_dataReceive" })
+	@Value("${de.netzwerk.universitaetsmedizin.codex.gecco.dataLoggingEnabled:false}")
+	private boolean dataLoggingEnabled;
 
 	@ProcessDocumentation(description = "Location of a FHIR batch bundle used to override the internally provided bundle used to search for GECCO FHIR ressources", processNames = "wwwnetzwerk-universitaetsmedizinde_dataSend")
 	@Value("${de.netzwerk.universitaetsmedizin.codex.gecco.server.search.bundle.override:#{null}}")
@@ -349,6 +356,12 @@ public class TransferDataConfig
 	}
 
 	@Bean
+	public DataLogger dataLogger()
+	{
+		return new DataLogger(dataLoggingEnabled, fhirContext());
+	}
+
+	@Bean
 	@SuppressWarnings("unchecked")
 	public GeccoClientFactory geccoClientFactory()
 	{
@@ -365,7 +378,7 @@ public class TransferDataConfig
 					fhirStoreProxyUsername, fhirStoreProxyPassword, fhirStoreHapiClientVerbose, fhirContext,
 					searchBundleOverride, localIdentifierValue,
 					(Class<GeccoFhirClient>) Class.forName(fhirStoreClientClass),
-					fhirStoreUseChainedParameterNotLogicalReference);
+					fhirStoreUseChainedParameterNotLogicalReference, dataLogger());
 		}
 		catch (ClassNotFoundException e)
 		{

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/ValidationConfig.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/ValidationConfig.java
@@ -490,7 +490,7 @@ public class ValidationConfig
 		if (validationEnabled)
 			logger.info(
 					"Testing connection to terminology server with {trustStorePath: {}, certificatePath: {}, privateKeyPath: {}, privateKeyPassword: {},"
-							+ " basicAuthUsername {}, basicAuthPassword {}, serverBase: {}, proxyUrl {}, proxyUsername {}, proxyPassword {}}{}",
+							+ " basicAuthUsername {}, basicAuthPassword {}, serverBase: {}, proxyUrl {}, proxyUsername {}, proxyPassword {}}",
 					valueSetExpansionClientTrustCertificates, valueSetExpansionClientCertificate,
 					valueSetExpansionClientCertificatePrivateKey,
 					valueSetExpansionClientCertificatePrivateKeyPassword != null ? "***" : "null",

--- a/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/AbstractFhirClientTest.java
+++ b/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/client/fhir/AbstractFhirClientTest.java
@@ -23,6 +23,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.domain.DateWithPrecision;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 
 public class AbstractFhirClientTest
 {
@@ -33,11 +34,12 @@ public class AbstractFhirClientTest
 	{
 		FhirContext fhirContext = FhirContext.forR4();
 		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		DataLogger dataLogger = Mockito.mock(DataLogger.class);
 		when(geccoClient.getSearchBundleOverride())
 				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
 		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
 		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
-				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+				Mockito.withSettings().useConstructor(geccoClient, dataLogger).defaultAnswer(CALLS_REAL_METHODS));
 
 		Date exportTo = new Date();
 
@@ -65,11 +67,12 @@ public class AbstractFhirClientTest
 	{
 		FhirContext fhirContext = FhirContext.forR4();
 		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		DataLogger dataLogger = Mockito.mock(DataLogger.class);
 		when(geccoClient.getSearchBundleOverride())
 				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
 		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
 		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
-				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+				Mockito.withSettings().useConstructor(geccoClient, dataLogger).defaultAnswer(CALLS_REAL_METHODS));
 
 		DateWithPrecision exportFrom = new DateWithPrecision(new Date(), TemporalPrecisionEnum.MILLI);
 		Date exportTo = new Date();
@@ -99,11 +102,12 @@ public class AbstractFhirClientTest
 	{
 		FhirContext fhirContext = FhirContext.forR4();
 		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		DataLogger dataLogger = Mockito.mock(DataLogger.class);
 		when(geccoClient.getSearchBundleOverride())
 				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
 		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
 		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
-				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+				Mockito.withSettings().useConstructor(geccoClient, dataLogger).defaultAnswer(CALLS_REAL_METHODS));
 
 		String patientId = "some-patient-id";
 		DateWithPrecision exportFrom = new DateWithPrecision(new Date(), TemporalPrecisionEnum.MILLI);
@@ -134,11 +138,12 @@ public class AbstractFhirClientTest
 	{
 		FhirContext fhirContext = FhirContext.forR4();
 		GeccoClient geccoClient = Mockito.mock(GeccoClient.class);
+		DataLogger dataLogger = Mockito.mock(DataLogger.class);
 		when(geccoClient.getSearchBundleOverride())
 				.thenReturn(Paths.get("src/main/resources/fhir/Bundle/SearchBundle.xml"));
 		when(geccoClient.getFhirContext()).thenReturn(fhirContext);
 		AbstractFhirClient client = Mockito.mock(AbstractFhirClient.class,
-				Mockito.withSettings().useConstructor(geccoClient).defaultAnswer(CALLS_REAL_METHODS));
+				Mockito.withSettings().useConstructor(geccoClient, dataLogger).defaultAnswer(CALLS_REAL_METHODS));
 
 		String pseudonym = "some-pseudonym";
 		DateWithPrecision exportFrom = new DateWithPrecision(new Date(), TemporalPrecisionEnum.MILLI);

--- a/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/send/ReadDataTest.java
+++ b/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/send/ReadDataTest.java
@@ -42,6 +42,7 @@ import ca.uhn.fhir.context.FhirContext;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClient;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.GeccoClientFactory;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.client.fhir.GeccoFhirClient;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.logging.DataLogger;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.variables.PatientReference;
 
 public class ReadDataTest
@@ -61,8 +62,9 @@ public class ReadDataTest
 		Mockito.when(geccoClient.getFhirClient()).thenReturn(fhirClient);
 		Mockito.when(fhirClient.getNewData(Mockito.any(), Mockito.any(), Mockito.any()))
 				.thenReturn(readBundle(fhirContext));
+		DataLogger dataLogger = Mockito.mock(DataLogger.class);
 
-		ReadData readData = new ReadData(clientProvider, taskHelper, readAccessHelper, fhirContext, geccoClientFactory);
+		ReadData readData = new ReadData(clientProvider, taskHelper, readAccessHelper, geccoClientFactory, dataLogger);
 		DelegateExecution execution = Mockito.mock(DelegateExecution.class);
 		Mockito.when(execution.getCurrentActivityId()).thenReturn(UUID.randomUUID().toString());
 		Mockito.when(execution.getVariable(BPMN_EXECUTION_VARIABLE_PATIENT_REFERENCE)).thenReturn(PatientReference

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithAbsoluteReference.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithAbsoluteReference.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithIdentifierReference.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithIdentifierReference.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataTrigger.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataTrigger.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-trigger|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-trigger|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStopDataTrigger.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStopDataTrigger.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-stop-data-trigger|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-stop-data-trigger|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>


### PR DESCRIPTION
* Fixes small issues in Log-Messages
* Adds a new DataLogger class, that is now resposible for logging search, search-result and transfer Bundles. The DataLogger is disabled by default and can be enabled using the property `de.netzwerk.universitaetsmedizin.codex.gecco.dataLoggingEnabled` or environment variable `DE_NETZWERK_UNIVERSITAETSMEDIZIN_CODEX_GECCO_DATALOGGINGENABLED`.

fixes #81 