### PR TITLE
adds dry-run functionality to data-send process

### DIFF
--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/ConstantsDataTransfer.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/ConstantsDataTransfer.java
@@ -25,6 +25,7 @@ public interface ConstantsDataTransfer
 	String BPMN_EXECUTION_VARIABLE_CONTINUE_STATUS = "continueStatus";
 	String BPMN_EXECUTION_VARIABLE_RETURN_TARGET = "returnTarget";
 	String BPMN_EXECUTION_VARIABLE_SOURCE_IDS_BY_BUNDLE_UUID = "sourceIdsByBundleUuid";
+	String BPMN_EXECUTION_VARIABLE_DRY_RUN = "dryRun";
 
 	String NAMING_SYSTEM_NUM_CODEX_DIC_PSEUDONYM = "http://www.netzwerk-universitaetsmedizin.de/sid/dic-pseudonym";
 	String NAMING_SYSTEM_NUM_CODEX_CRR_PSEUDONYM = "http://www.netzwerk-universitaetsmedizin.de/sid/crr-pseudonym";
@@ -41,6 +42,7 @@ public interface ConstantsDataTransfer
 	String CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_EXPORT_FROM = "export-from";
 	String CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_EXPORT_TO = "export-to";
 	String CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DATA_REFERENCE = "data-reference";
+	String CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DRY_RUN = "dry-run";
 
 	String PROFILE_NUM_CODEX_TASK_DATA_TRIGGER_PROCESS_URI = "http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/";
 	String PROFILE_NUM_CODEX_TASK_DATA_TRIGGER_PROCESS_URI_AND_LATEST_VERSION = PROFILE_NUM_CODEX_TASK_DATA_TRIGGER_PROCESS_URI

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/DataTransferProcessPluginDefinition.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/DataTransferProcessPluginDefinition.java
@@ -36,8 +36,8 @@ public class DataTransferProcessPluginDefinition implements ProcessPluginDefinit
 {
 	private static final Logger logger = LoggerFactory.getLogger(DataTransferProcessPluginDefinition.class);
 
-	public static final String VERSION = "0.5.1";
-	public static final LocalDate DATE = LocalDate.of(2022, 6, 25);
+	public static final String VERSION = "0.6.0";
+	public static final LocalDate DATE = LocalDate.of(2022, 7, 12);
 
 	@Override
 	public String getName()

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/send/CheckDryRun.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/send/CheckDryRun.java
@@ -1,0 +1,36 @@
+package de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send;
+
+import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.BPMN_EXECUTION_VARIABLE_DRY_RUN;
+import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER;
+import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DRY_RUN;
+
+import java.util.Optional;
+
+import org.camunda.bpm.engine.delegate.BpmnError;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.variable.Variables;
+import org.highmed.dsf.bpe.delegate.AbstractServiceDelegate;
+import org.highmed.dsf.fhir.authorization.read.ReadAccessHelper;
+import org.highmed.dsf.fhir.client.FhirWebserviceClientProvider;
+import org.highmed.dsf.fhir.task.TaskHelper;
+import org.hl7.fhir.r4.model.Task;
+
+public class CheckDryRun extends AbstractServiceDelegate
+{
+	public CheckDryRun(FhirWebserviceClientProvider clientProvider, TaskHelper taskHelper,
+			ReadAccessHelper readAccessHelper)
+	{
+		super(clientProvider, taskHelper, readAccessHelper);
+	}
+
+	@Override
+	protected void doExecute(DelegateExecution execution) throws BpmnError, Exception
+	{
+		Task task = getLeadingTaskFromExecutionVariables();
+
+		Optional<Boolean> dryRun = getTaskHelper().getFirstInputParameterBooleanValue(task,
+				CODESYSTEM_NUM_CODEX_DATA_TRANSFER, CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DRY_RUN);
+
+		execution.setVariable(BPMN_EXECUTION_VARIABLE_DRY_RUN, Variables.booleanValue(dryRun.orElse(Boolean.FALSE)));
+	}
+}

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/send/LogDryRunSuccess.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/service/send/LogDryRunSuccess.java
@@ -1,0 +1,27 @@
+package de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send;
+
+import org.camunda.bpm.engine.delegate.BpmnError;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.highmed.dsf.bpe.delegate.AbstractServiceDelegate;
+import org.highmed.dsf.fhir.authorization.read.ReadAccessHelper;
+import org.highmed.dsf.fhir.client.FhirWebserviceClientProvider;
+import org.highmed.dsf.fhir.task.TaskHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogDryRunSuccess extends AbstractServiceDelegate
+{
+	private static final Logger logger = LoggerFactory.getLogger(LogSuccess.class);
+
+	public LogDryRunSuccess(FhirWebserviceClientProvider clientProvider, TaskHelper taskHelper,
+			ReadAccessHelper readAccessHelper)
+	{
+		super(clientProvider, taskHelper, readAccessHelper);
+	}
+
+	@Override
+	protected void doExecute(DelegateExecution execution) throws BpmnError, Exception
+	{
+		logger.info("Dry run successfully completed");
+	}
+}

--- a/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/SendConfig.java
+++ b/codex-process-data-transfer/src/main/java/de/netzwerk_universitaetsmedizin/codex/processes/data_transfer/spring/config/SendConfig.java
@@ -6,12 +6,14 @@ import org.springframework.context.annotation.Configuration;
 
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.message.StartTranslateProcess;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.CheckConsent;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.CheckDryRun;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.CheckForError;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.DecryptValidationErrorFromGth;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.DeleteDataForGth;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.DownloadValidationErrorFromGth;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.EncryptData;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.ExtractPatientReference;
+import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.LogDryRunSuccess;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.LogError;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.LogSuccess;
 import de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.LogValidationError;
@@ -88,6 +90,20 @@ public class SendConfig
 		return new EncryptData(transferDataConfig.fhirClientProvider(), transferDataConfig.taskHelper(),
 				transferDataConfig.readAccessHelper(), transferDataConfig.fhirContext(),
 				transferDataConfig.crrKeyProvider());
+	}
+
+	@Bean
+	public CheckDryRun checkDryRun()
+	{
+		return new CheckDryRun(transferDataConfig.fhirClientProvider(), transferDataConfig.taskHelper(),
+				transferDataConfig.readAccessHelper());
+	}
+
+	@Bean
+	public LogDryRunSuccess logDryRunSuccess()
+	{
+		return new LogDryRunSuccess(transferDataConfig.fhirClientProvider(), transferDataConfig.taskHelper(),
+				transferDataConfig.readAccessHelper());
 	}
 
 	@Bean

--- a/codex-process-data-transfer/src/main/resources/bpe/send.bpmn
+++ b/codex-process-data-transfer/src/main/resources/bpe/send.bpmn
@@ -24,9 +24,9 @@
       <bpmn:incoming>Flow_0zrvqk8</bpmn:incoming>
       <bpmn:outgoing>Flow_0smf5sr</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0smf5sr" sourceRef="EncryptData" targetRef="StoreDataForGth" />
+    <bpmn:sequenceFlow id="Flow_0smf5sr" sourceRef="EncryptData" targetRef="CheckDryRun" />
     <bpmn:serviceTask id="StoreDataForGth" name="store data for GTH" camunda:class="de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.StoreDataForGth">
-      <bpmn:incoming>Flow_0smf5sr</bpmn:incoming>
+      <bpmn:incoming>Flow_1fl07dr</bpmn:incoming>
       <bpmn:outgoing>Flow_12gk2sv</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_0h3dkik">
@@ -273,6 +273,30 @@
       <bpmn:errorEventDefinition id="ErrorEventDefinition_0vb2e87" camunda:errorCodeVariable="errorCode" camunda:errorMessageVariable="errorMessage" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_1jjbgmm" sourceRef="Event_1iglx21" targetRef="Gateway_13fyv2x" />
+    <bpmn:exclusiveGateway id="Gateway_056qqty">
+      <bpmn:incoming>Flow_1fuo1n3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fl07dr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1okvceo</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1fl07dr" sourceRef="Gateway_056qqty" targetRef="StoreDataForGth">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!dryRun}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1okvceo" name="dry run" sourceRef="Gateway_056qqty" targetRef="LogDryRunSuccess">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${dryRun}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0ww5gaz">
+      <bpmn:incoming>Flow_13ulpon</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_13ulpon" sourceRef="LogDryRunSuccess" targetRef="Event_0ww5gaz" />
+    <bpmn:serviceTask id="LogDryRunSuccess" name="log dry run success" camunda:class="de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.LogDryRunSuccess">
+      <bpmn:incoming>Flow_1okvceo</bpmn:incoming>
+      <bpmn:outgoing>Flow_13ulpon</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1fuo1n3" sourceRef="CheckDryRun" targetRef="Gateway_056qqty" />
+    <bpmn:serviceTask id="CheckDryRun" name="check dry run" camunda:class="de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.service.send.CheckDryRun">
+      <bpmn:incoming>Flow_0smf5sr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fuo1n3</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmn:message id="Message_1c7e014" name="stopTimer" />
   <bpmn:message id="Message_1u007k0" name="startTimer" />
@@ -285,159 +309,172 @@
   <bpmn:message id="Message_0pk1d02" name="continueDataSend" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="wwwnetzwerk-universitaetsmedizinde_dataSend">
+      <bpmndi:BPMNEdge id="Flow_1jjbgmm_di" bpmnElement="Flow_1jjbgmm">
+        <di:waypoint x="2060" y="178" />
+        <di:waypoint x="2060" y="530" />
+        <di:waypoint x="3215" y="530" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_037geje_di" bpmnElement="Flow_037geje">
+        <di:waypoint x="2060" y="120" />
+        <di:waypoint x="2125" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12gk2sv_di" bpmnElement="Flow_12gk2sv">
+        <di:waypoint x="1900" y="120" />
+        <di:waypoint x="1960" y="120" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_115gsvw_di" bpmnElement="Flow_115gsvw">
-        <di:waypoint x="2320" y="120" />
-        <di:waypoint x="2400" y="120" />
+        <di:waypoint x="2590" y="120" />
+        <di:waypoint x="2670" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yofyrq_di" bpmnElement="Flow_0yofyrq">
-        <di:waypoint x="2018" y="450" />
-        <di:waypoint x="2070" y="450" />
+        <di:waypoint x="2288" y="450" />
+        <di:waypoint x="2340" y="450" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dsdmf9_di" bpmnElement="Flow_1dsdmf9">
-        <di:waypoint x="1880" y="145" />
-        <di:waypoint x="1880" y="450" />
-        <di:waypoint x="1982" y="450" />
+        <di:waypoint x="2150" y="145" />
+        <di:waypoint x="2150" y="450" />
+        <di:waypoint x="2252" y="450" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0egy89t_di" bpmnElement="Flow_0egy89t">
-        <di:waypoint x="1880" y="145" />
-        <di:waypoint x="1880" y="340" />
-        <di:waypoint x="1982" y="340" />
+        <di:waypoint x="2150" y="145" />
+        <di:waypoint x="2150" y="340" />
+        <di:waypoint x="2252" y="340" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lcotqz_di" bpmnElement="Flow_0lcotqz">
-        <di:waypoint x="1880" y="145" />
-        <di:waypoint x="1880" y="230" />
-        <di:waypoint x="1982" y="230" />
+        <di:waypoint x="2150" y="145" />
+        <di:waypoint x="2150" y="230" />
+        <di:waypoint x="2252" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1pyjkzx_di" bpmnElement="Flow_1pyjkzx">
-        <di:waypoint x="1905" y="120" />
-        <di:waypoint x="1982" y="120" />
+        <di:waypoint x="2175" y="120" />
+        <di:waypoint x="2252" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_075p3fz_di" bpmnElement="Flow_075p3fz">
-        <di:waypoint x="2145" y="120" />
-        <di:waypoint x="2220" y="120" />
+        <di:waypoint x="2415" y="120" />
+        <di:waypoint x="2490" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0tjvgz8_di" bpmnElement="Flow_0tjvgz8">
-        <di:waypoint x="2018" y="230" />
-        <di:waypoint x="2120" y="230" />
-        <di:waypoint x="2120" y="145" />
+        <di:waypoint x="2288" y="230" />
+        <di:waypoint x="2390" y="230" />
+        <di:waypoint x="2390" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0soepqw_di" bpmnElement="Flow_0soepqw">
-        <di:waypoint x="2018" y="340" />
-        <di:waypoint x="2120" y="340" />
-        <di:waypoint x="2120" y="145" />
+        <di:waypoint x="2288" y="340" />
+        <di:waypoint x="2390" y="340" />
+        <di:waypoint x="2390" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_009empz_di" bpmnElement="Flow_009empz">
-        <di:waypoint x="2018" y="120" />
-        <di:waypoint x="2095" y="120" />
+        <di:waypoint x="2288" y="120" />
+        <di:waypoint x="2365" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tal48r_di" bpmnElement="Flow_1tal48r">
-        <di:waypoint x="2120" y="410" />
-        <di:waypoint x="2120" y="145" />
+        <di:waypoint x="2390" y="410" />
+        <di:waypoint x="2390" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ogw7no_di" bpmnElement="Flow_0ogw7no">
-        <di:waypoint x="2500" y="120" />
-        <di:waypoint x="2565" y="120" />
+        <di:waypoint x="2770" y="120" />
+        <di:waypoint x="2835" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1yqcwpb_di" bpmnElement="Flow_1yqcwpb">
-        <di:waypoint x="3140" y="250" />
-        <di:waypoint x="3212" y="250" />
+        <di:waypoint x="3410" y="250" />
+        <di:waypoint x="3482" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wqrp5a_di" bpmnElement="Flow_0wqrp5a">
-        <di:waypoint x="2970" y="308" />
-        <di:waypoint x="2970" y="505" />
+        <di:waypoint x="3240" y="308" />
+        <di:waypoint x="3240" y="505" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1fe76g6_di" bpmnElement="Flow_1fe76g6">
-        <di:waypoint x="2970" y="250" />
-        <di:waypoint x="3040" y="250" />
+        <di:waypoint x="3240" y="250" />
+        <di:waypoint x="3310" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1j2hn6l_di" bpmnElement="Flow_1j2hn6l">
-        <di:waypoint x="2780" y="250" />
-        <di:waypoint x="2870" y="250" />
+        <di:waypoint x="3050" y="250" />
+        <di:waypoint x="3140" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ojlya5_di" bpmnElement="Flow_1ojlya5">
         <di:waypoint x="370" y="178" />
         <di:waypoint x="370" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yow5g2_di" bpmnElement="Flow_0yow5g2">
         <di:waypoint x="540" y="178" />
         <di:waypoint x="540" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04t997c_di" bpmnElement="Flow_04t997c">
-        <di:waypoint x="670" y="490" />
-        <di:waypoint x="670" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="650" y="490" />
+        <di:waypoint x="650" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18cfw7e_di" bpmnElement="Flow_18cfw7e">
-        <di:waypoint x="870" y="288" />
-        <di:waypoint x="870" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="850" y="288" />
+        <di:waypoint x="850" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0nrf7fq_di" bpmnElement="Flow_0nrf7fq">
-        <di:waypoint x="970" y="490" />
-        <di:waypoint x="970" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="950" y="490" />
+        <di:waypoint x="950" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_040kkv8_di" bpmnElement="Flow_040kkv8">
-        <di:waypoint x="1160" y="178" />
-        <di:waypoint x="1160" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="1140" y="178" />
+        <di:waypoint x="1140" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0sy09vc_di" bpmnElement="Flow_0sy09vc">
-        <di:waypoint x="1320" y="178" />
-        <di:waypoint x="1320" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="1300" y="178" />
+        <di:waypoint x="1300" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mff8mx_di" bpmnElement="Flow_1mff8mx">
-        <di:waypoint x="1480" y="178" />
-        <di:waypoint x="1480" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="1460" y="178" />
+        <di:waypoint x="1460" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01cz1ir_di" bpmnElement="Flow_01cz1ir">
-        <di:waypoint x="1640" y="178" />
-        <di:waypoint x="1640" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="1900" y="178" />
+        <di:waypoint x="1900" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ervxi8_di" bpmnElement="Flow_0ervxi8">
-        <di:waypoint x="2590" y="145" />
-        <di:waypoint x="2590" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="2860" y="145" />
+        <di:waypoint x="2860" y="530" />
+        <di:waypoint x="3215" y="530" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2501" y="173" width="77" height="14" />
+          <dc:Bounds x="2771" y="173" width="77" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ixpqv3_di" bpmnElement="Flow_0ixpqv3">
-        <di:waypoint x="3140" y="120" />
-        <di:waypoint x="3212" y="120" />
+        <di:waypoint x="3410" y="120" />
+        <di:waypoint x="3482" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_188eh1h_di" bpmnElement="Flow_188eh1h">
-        <di:waypoint x="3140" y="530" />
-        <di:waypoint x="3212" y="530" />
+        <di:waypoint x="3410" y="530" />
+        <di:waypoint x="3482" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_16ouahu_di" bpmnElement="Flow_16ouahu">
-        <di:waypoint x="2995" y="530" />
-        <di:waypoint x="3040" y="530" />
+        <di:waypoint x="3265" y="530" />
+        <di:waypoint x="3310" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1784u2y_di" bpmnElement="Flow_1784u2y">
-        <di:waypoint x="2780" y="308" />
-        <di:waypoint x="2780" y="530" />
-        <di:waypoint x="2945" y="530" />
+        <di:waypoint x="3050" y="308" />
+        <di:waypoint x="3050" y="530" />
+        <di:waypoint x="3215" y="530" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0s9c6mf_di" bpmnElement="Flow_0s9c6mf">
-        <di:waypoint x="2603" y="133" />
-        <di:waypoint x="2640" y="170" />
-        <di:waypoint x="2640" y="250" />
-        <di:waypoint x="2680" y="250" />
+        <di:waypoint x="2873" y="133" />
+        <di:waypoint x="2910" y="170" />
+        <di:waypoint x="2910" y="250" />
+        <di:waypoint x="2950" y="250" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2653" y="173" width="74" height="14" />
+          <dc:Bounds x="2923" y="173" width="74" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1yj09fp_di" bpmnElement="Flow_1yj09fp">
-        <di:waypoint x="2615" y="120" />
-        <di:waypoint x="3040" y="120" />
+        <di:waypoint x="2885" y="120" />
+        <di:waypoint x="3310" y="120" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2620" y="100" width="40" height="14" />
+          <dc:Bounds x="2890" y="100" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_06456ku_di" bpmnElement="Flow_06456ku">
@@ -445,79 +482,85 @@
         <di:waypoint x="440" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0pt6h5d_di" bpmnElement="Flow_0pt6h5d">
-        <di:waypoint x="670" y="255" />
-        <di:waypoint x="670" y="410" />
+        <di:waypoint x="650" y="255" />
+        <di:waypoint x="650" y="410" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="581" y="261" width="78" height="27" />
+          <dc:Bounds x="571" y="261" width="78" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_05s6sr1_di" bpmnElement="Flow_05s6sr1">
-        <di:waypoint x="695" y="230" />
-        <di:waypoint x="770" y="230" />
+        <di:waypoint x="675" y="230" />
+        <di:waypoint x="750" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wugx7a_di" bpmnElement="Flow_0wugx7a">
-        <di:waypoint x="670" y="145" />
-        <di:waypoint x="670" y="205" />
+        <di:waypoint x="650" y="145" />
+        <di:waypoint x="650" y="205" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="583" y="166" width="73" height="27" />
+          <dc:Bounds x="573" y="166" width="73" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0odw7ag_di" bpmnElement="Flow_0odw7ag">
-        <di:waypoint x="695" y="120" />
-        <di:waypoint x="945" y="120" />
+        <di:waypoint x="675" y="120" />
+        <di:waypoint x="925" y="120" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="707" y="100" width="64" height="14" />
+          <dc:Bounds x="687" y="100" width="64" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_12xkou2_di" bpmnElement="Flow_12xkou2">
-        <di:waypoint x="820" y="190" />
-        <di:waypoint x="820" y="160" />
-        <di:waypoint x="930" y="160" />
-        <di:waypoint x="958" y="133" />
+        <di:waypoint x="800" y="190" />
+        <di:waypoint x="800" y="160" />
+        <di:waypoint x="910" y="160" />
+        <di:waypoint x="938" y="133" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0g5a4jz_di" bpmnElement="Flow_0g5a4jz">
         <di:waypoint x="540" y="120" />
-        <di:waypoint x="645" y="120" />
+        <di:waypoint x="625" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0tsm3rc_di" bpmnElement="Flow_0tsm3rc">
-        <di:waypoint x="970" y="145" />
-        <di:waypoint x="970" y="410" />
+        <di:waypoint x="950" y="145" />
+        <di:waypoint x="950" y="410" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="985" y="196" width="69" height="40" />
+          <dc:Bounds x="955" y="180" width="69" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wpfzi1_di" bpmnElement="Flow_0wpfzi1">
-        <di:waypoint x="995" y="120" />
-        <di:waypoint x="1060" y="120" />
+        <di:waypoint x="975" y="120" />
+        <di:waypoint x="1040" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0smf5sr_di" bpmnElement="Flow_0smf5sr">
-        <di:waypoint x="1480" y="120" />
-        <di:waypoint x="1540" y="120" />
+        <di:waypoint x="1460" y="120" />
+        <di:waypoint x="1520" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zrvqk8_di" bpmnElement="Flow_0zrvqk8">
-        <di:waypoint x="1320" y="120" />
-        <di:waypoint x="1380" y="120" />
+        <di:waypoint x="1300" y="120" />
+        <di:waypoint x="1360" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yamo5r_di" bpmnElement="Flow_0yamo5r">
-        <di:waypoint x="1160" y="120" />
-        <di:waypoint x="1220" y="120" />
+        <di:waypoint x="1140" y="120" />
+        <di:waypoint x="1200" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1km61ly_di" bpmnElement="Flow_1km61ly">
         <di:waypoint x="198" y="120" />
         <di:waypoint x="270" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12gk2sv_di" bpmnElement="Flow_12gk2sv">
-        <di:waypoint x="1640" y="120" />
-        <di:waypoint x="1700" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_037geje_di" bpmnElement="Flow_037geje">
+      <bpmndi:BPMNEdge id="Flow_1fl07dr_di" bpmnElement="Flow_1fl07dr">
+        <di:waypoint x="1735" y="120" />
         <di:waypoint x="1800" y="120" />
-        <di:waypoint x="1855" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1jjbgmm_di" bpmnElement="Flow_1jjbgmm">
-        <di:waypoint x="1800" y="178" />
-        <di:waypoint x="1800" y="530" />
-        <di:waypoint x="2945" y="530" />
+      <bpmndi:BPMNEdge id="Flow_1okvceo_di" bpmnElement="Flow_1okvceo">
+        <di:waypoint x="1710" y="145" />
+        <di:waypoint x="1710" y="190" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1722" y="163" width="35" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13ulpon_di" bpmnElement="Flow_13ulpon">
+        <di:waypoint x="1710" y="270" />
+        <di:waypoint x="1710" y="322" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fuo1n3_di" bpmnElement="Flow_1fuo1n3">
+        <di:waypoint x="1620" y="120" />
+        <di:waypoint x="1685" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0kggab9_di" bpmnElement="DataSendMessageStartEvent">
         <dc:Bounds x="162" y="102" width="36" height="36" />
@@ -528,107 +571,119 @@
       <bpmndi:BPMNShape id="Activity_1e4ychv_di" bpmnElement="CheckConsent">
         <dc:Bounds x="440" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0p0ebgq_di" bpmnElement="ReadData">
-        <dc:Bounds x="1060" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0d1am14_di" bpmnElement="ValidateData">
-        <dc:Bounds x="1220" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0mi94m2_di" bpmnElement="EncryptData">
-        <dc:Bounds x="1380" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0d04yf5_di" bpmnElement="StoreDataForGth">
-        <dc:Bounds x="1540" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0h3dkik_di" bpmnElement="Gateway_0h3dkik" isMarkerVisible="true">
-        <dc:Bounds x="945" y="95" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1uvryxy_di" bpmnElement="SetNoConsentUsageAndTransferError">
-        <dc:Bounds x="920" y="410" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0pw7tym_di" bpmnElement="ExtractPatientReference">
         <dc:Bounds x="270" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0p0ebgq_di" bpmnElement="ReadData">
+        <dc:Bounds x="1040" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d1am14_di" bpmnElement="ValidateData">
+        <dc:Bounds x="1200" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mi94m2_di" bpmnElement="EncryptData">
+        <dc:Bounds x="1360" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0h3dkik_di" bpmnElement="Gateway_0h3dkik" isMarkerVisible="true">
+        <dc:Bounds x="925" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1uvryxy_di" bpmnElement="SetNoConsentUsageAndTransferError">
+        <dc:Bounds x="900" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1btox3g_di" bpmnElement="ResolvePsn">
-        <dc:Bounds x="770" y="190" width="100" height="80" />
+        <dc:Bounds x="750" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0qci4qw_di" bpmnElement="Gateway_0qci4qw" isMarkerVisible="true">
-        <dc:Bounds x="645" y="95" width="50" height="50" />
+        <dc:Bounds x="625" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_090s0pr_di" bpmnElement="SetNoConsentIdatMergeError">
-        <dc:Bounds x="620" y="410" width="100" height="80" />
+        <dc:Bounds x="600" y="410" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0ii6gnq_di" bpmnElement="Gateway_0ii6gnq" isMarkerVisible="true">
-        <dc:Bounds x="645" y="205" width="50" height="50" />
+        <dc:Bounds x="625" y="205" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1i5l6p1_di" bpmnElement="LogDryRunSuccess">
+        <dc:Bounds x="1660" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_056qqty_di" bpmnElement="Gateway_056qqty" isMarkerVisible="true">
+        <dc:Bounds x="1685" y="95" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ww5gaz_di" bpmnElement="Event_0ww5gaz">
+        <dc:Bounds x="1692" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d04yf5_di" bpmnElement="StoreDataForGth">
+        <dc:Bounds x="1800" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cf00bl_di" bpmnElement="StartDataTranslateProcess">
+        <dc:Bounds x="1960" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0og5zib_di" bpmnElement="DeleteDataForGth">
-        <dc:Bounds x="2400" y="80" width="100" height="80" />
+        <dc:Bounds x="2670" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0if37bo_di" bpmnElement="Gateway_0if37bo" isMarkerVisible="true">
-        <dc:Bounds x="2565" y="95" width="50" height="50" />
+        <dc:Bounds x="2835" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1e8212a_di" bpmnElement="LogSuccess">
-        <dc:Bounds x="3040" y="80" width="100" height="80" />
+        <dc:Bounds x="3310" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1o2m082_di" bpmnElement="DownloadValidationErrorFromGth">
-        <dc:Bounds x="2680" y="210" width="100" height="80" />
+        <dc:Bounds x="2950" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0vorh8u_di" bpmnElement="LogError">
-        <dc:Bounds x="3040" y="490" width="100" height="80" />
+        <dc:Bounds x="3310" y="490" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_13fyv2x_di" bpmnElement="Gateway_13fyv2x" isMarkerVisible="true">
-        <dc:Bounds x="2945" y="505" width="50" height="50" />
+        <dc:Bounds x="3215" y="505" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gv80z3_di" bpmnElement="Event_0gv80z3">
-        <dc:Bounds x="3212" y="512" width="36" height="36" />
+        <dc:Bounds x="3482" y="512" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1pp5ms7_di" bpmnElement="Event_1pp5ms7">
-        <dc:Bounds x="3212" y="102" width="36" height="36" />
+        <dc:Bounds x="3482" y="102" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_140gxyq_di" bpmnElement="DecryptValidationErrorFromGth">
-        <dc:Bounds x="2870" y="210" width="100" height="80" />
+        <dc:Bounds x="3140" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0xc0fb0_di" bpmnElement="LogValidationError">
-        <dc:Bounds x="3040" y="210" width="100" height="80" />
+        <dc:Bounds x="3310" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0edfmnq_di" bpmnElement="Event_0edfmnq">
-        <dc:Bounds x="3212" y="232" width="36" height="36" />
+        <dc:Bounds x="3482" y="232" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1lp4ez4_di" bpmnElement="Gateway_1lp4ez4" isMarkerVisible="true">
-        <dc:Bounds x="2095" y="95" width="50" height="50" />
+        <dc:Bounds x="2365" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_07s23p6_di" bpmnElement="Gateway_1msqj8s">
-        <dc:Bounds x="1855" y="95" width="50" height="50" />
+        <dc:Bounds x="2125" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1gmzyd0_di" bpmnElement="Event_1gmzyd0">
-        <dc:Bounds x="1982" y="432" width="36" height="36" />
+        <dc:Bounds x="2252" y="432" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lvtt2z_di" bpmnElement="SetTimeoutError">
-        <dc:Bounds x="2070" y="410" width="100" height="80" />
+        <dc:Bounds x="2340" y="410" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_18orse0_di" bpmnElement="ContinueDataSend">
-        <dc:Bounds x="1982" y="102" width="36" height="36" />
+        <dc:Bounds x="2252" y="102" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1966" y="145" width="69" height="27" />
+          <dc:Bounds x="2236" y="145" width="69" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_10mjddt_di" bpmnElement="ContinueDataSendWithValidationError">
-        <dc:Bounds x="1982" y="212" width="36" height="36" />
+        <dc:Bounds x="2252" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1963" y="255" width="74" height="40" />
+          <dc:Bounds x="2233" y="255" width="74" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_16c4tg0_di" bpmnElement="ContinueDataSendWithError">
-        <dc:Bounds x="1982" y="322" width="36" height="36" />
+        <dc:Bounds x="2252" y="322" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1956" y="365" width="89" height="27" />
+          <dc:Bounds x="2226" y="365" width="89" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1xl8e8s_di" bpmnElement="CheckForError">
-        <dc:Bounds x="2220" y="80" width="100" height="80" />
+        <dc:Bounds x="2490" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1cf00bl_di" bpmnElement="StartDataTranslateProcess">
-        <dc:Bounds x="1700" y="80" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0za4t5y_di" bpmnElement="CheckDryRun">
+        <dc:Bounds x="1520" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qzm2eh_di" bpmnElement="Event_09702b0">
         <dc:Bounds x="352" y="142" width="36" height="36" />
@@ -637,28 +692,28 @@
         <dc:Bounds x="522" y="142" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1w7mplr_di" bpmnElement="Event_0wsri1t">
-        <dc:Bounds x="852" y="252" width="36" height="36" />
+        <dc:Bounds x="832" y="252" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0f6gwws_di" bpmnElement="Event_1h36t2u">
-        <dc:Bounds x="1142" y="142" width="36" height="36" />
+        <dc:Bounds x="1122" y="142" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0b3ejr5_di" bpmnElement="Event_0c8ajbv">
-        <dc:Bounds x="1302" y="142" width="36" height="36" />
+        <dc:Bounds x="1282" y="142" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1jv2po6_di" bpmnElement="Event_1l3631s">
-        <dc:Bounds x="1462" y="142" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0fkfgqj_di" bpmnElement="Event_1cqf68a">
-        <dc:Bounds x="1622" y="142" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qeyaib_di" bpmnElement="Event_1wqk00d">
-        <dc:Bounds x="2952" y="272" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0z6ujob_di" bpmnElement="Event_0z6ujob">
-        <dc:Bounds x="2762" y="272" width="36" height="36" />
+        <dc:Bounds x="1442" y="142" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0nmntjp_di" bpmnElement="Event_1iglx21">
-        <dc:Bounds x="1782" y="142" width="36" height="36" />
+        <dc:Bounds x="2042" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0fkfgqj_di" bpmnElement="Event_1cqf68a">
+        <dc:Bounds x="1882" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1qeyaib_di" bpmnElement="Event_1wqk00d">
+        <dc:Bounds x="3222" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0z6ujob_di" bpmnElement="Event_0z6ujob">
+        <dc:Bounds x="3032" y="272" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/codex-process-data-transfer/src/main/resources/fhir/CodeSystem/num-codex-data-transfer.xml
+++ b/codex-process-data-transfer/src/main/resources/fhir/CodeSystem/num-codex-data-transfer.xml
@@ -46,4 +46,9 @@
 		<display value="Export To" />
 		<definition value="Date parameter to filter resources last modified until (exclusive) the specified date" />
 	</concept>
+	<concept>
+		<code value="dry-run" />
+		<display value="Dry Run" />
+		<definition value="Boolean parameter to do a data send process dry run only (no actual data transfer to GTH/CRR)" />
+	</concept>
 </CodeSystem> 

--- a/codex-process-data-transfer/src/main/resources/fhir/StructureDefinition/num-codex-task-start-data-send.xml
+++ b/codex-process-data-transfer/src/main/resources/fhir/StructureDefinition/num-codex-task-start-data-send.xml
@@ -26,7 +26,7 @@
     <element id="Task.input">
       <path value="Task.input" />
       <min value="3" />
-      <max value="5" />
+      <max value="6" />
     </element>
     <element id="Task.input:message-name">
       <path value="Task.input" />
@@ -142,6 +142,40 @@
       <path value="Task.input.value[x]" />
       <type>
         <code value="instant" />
+      </type>
+    </element>
+    <element id="Task.input:dry-run">
+      <path value="Task.input" />
+      <sliceName value="dry-run" />
+      <min value="0" />
+      <max value="1" />
+    </element>
+    <element id="Task.input:dry-run.type">
+      <path value="Task.input.type" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://www.netzwerk-universitaetsmedizin.de/fhir/ValueSet/data-transfer" />
+      </binding>
+    </element>
+    <element id="Task.input:dry-run.type.coding">
+      <path value="Task.input.type.coding" />
+      <min value="1" />
+      <max value="1" />
+    </element>
+    <element id="Task.input:dry-run.type.coding.system">
+      <path value="Task.input.type.coding.system" />
+      <min value="1" />
+      <fixedUri value="http://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/data-transfer" />
+    </element>
+    <element id="Task.input:dry-run.type.coding.code">
+      <path value="Task.input.type.coding.code" />
+      <min value="1" />
+      <fixedCode value="dry-run" />
+    </element>
+    <element id="Task.input:dry-run.value[x]">
+      <path value="Task.input.value[x]" />
+      <type>
+        <code value="boolean" />
       </type>
     </element>
     <element id="Task.output:error">

--- a/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/fhir/profile/TaskProfileTest.java
+++ b/codex-process-data-transfer/src/test/java/de/netzwerk_universitaetsmedizin/codex/processes/fhir/profile/TaskProfileTest.java
@@ -4,6 +4,7 @@ import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.Con
 import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_ERROR_VALUE_DOWNLOAD_DATA_FROM_DIC_FAILED;
 import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_ERROR_VALUE_DOWNLOAD_DATA_FROM_GTH_FAILED;
 import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DATA_REFERENCE;
+import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DRY_RUN;
 import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_EXPORT_FROM;
 import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_EXPORT_TO;
 import static de.netzwerk_universitaetsmedizin.codex.processes.data_transfer.ConstantsDataTransfer.CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_PATIENT;
@@ -51,6 +52,7 @@ import java.util.UUID;
 import org.highmed.dsf.fhir.validation.ResourceValidator;
 import org.highmed.dsf.fhir.validation.ResourceValidatorImpl;
 import org.highmed.dsf.fhir.validation.ValidationSupportRule;
+import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Identifier;
@@ -335,6 +337,22 @@ public class TaskProfileTest
 				.setCode(CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_EXPORT_TO);
 
 		return task;
+	}
+
+	@Test
+	public void testTaskStartDataSendDryRun() throws Exception
+	{
+		Task task = createValidTaskStartDataSendWithIdentifierReference();
+		task.addInput().setValue(new BooleanType(true)).getType().addCoding()
+				.setSystem(CODESYSTEM_NUM_CODEX_DATA_TRANSFER)
+				.setCode(CODESYSTEM_NUM_CODEX_DATA_TRANSFER_VALUE_DRY_RUN);
+		logTask(task);
+
+		ValidationResult result = resourceValidator.validate(task);
+		ValidationSupportRule.logValidationMessages(logger, result);
+
+		assertEquals(0, result.getMessages().stream().filter(m -> ResultSeverityEnum.ERROR.equals(m.getSeverity())
+				|| ResultSeverityEnum.FATAL.equals(m.getSeverity())).count());
 	}
 
 	@Test

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithAbsoluteReference.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithAbsoluteReference.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>
@@ -67,5 +67,18 @@
          </coding>
       </type>
       <valueDateTime value="2020-06-25T00:00:00+01:00"/>
+   </input> -->
+   <!-- optional parameter enabling a dry run of the data-send process. Specifying the
+		'dry-run' parameter with value 'true' will result in the data-send process
+		aborting before storing the encrypted transfer bundle in the local DSF FHIR server
+		and sending a Task to start the data-translate process to the GTH -->
+   <!-- <input>
+      <type>
+         <coding>
+            <system value="http://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/data-transfer"/>
+            <code value="dry-run"/>
+         </coding>
+      </type>
+      <valueBoolean value="true"/>
    </input> -->
 </Task>

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithIdentifierReference.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataSendWithIdentifierReference.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-send|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataSend/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>
@@ -72,5 +72,18 @@
          </coding>
       </type>
       <valueDateTime value="2020-06-25T00:00:00+01:00"/>
+   </input> -->
+   <!-- optional parameter enabling a dry run of the data-send process. Specifying the
+		'dry-run' parameter with value 'true' will result in the data-send process
+		aborting before storing the encrypted transfer bundle in the local DSF FHIR server
+		and sending a Task to start the data-translate process to the GTH -->
+   <!-- <input>
+      <type>
+         <coding>
+            <system value="http://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/data-transfer"/>
+            <code value="dry-run"/>
+         </coding>
+      </type>
+      <valueBoolean value="true"/>
    </input> -->
 </Task>

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataTrigger.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStartDataTrigger.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-trigger|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-start-data-trigger|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>

--- a/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStopDataTrigger.xml
+++ b/codex-process-data-transfer/src/test/resources/fhir/Task/TaskStopDataTrigger.xml
@@ -1,8 +1,8 @@
 <Task xmlns="http://hl7.org/fhir">
    <meta>
-      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-stop-data-trigger|0.5.1"/>
+      <profile value="http://www.netzwerk-universitaetsmedizin.de/fhir/StructureDefinition/task-stop-data-trigger|0.6.0"/>
    </meta>
-   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.5.1"/>
+   <instantiatesUri value="http://www.netzwerk-universitaetsmedizin.de/bpe/Process/dataTrigger/0.6.0"/>
    <status value="requested"/>
    <intent value="order"/>
    <authoredOn value="2022-06-25T12:00:00+01:00"/>


### PR DESCRIPTION
The data-send process can now be instructed to perform a dry-run only using the optional input-parameter "dry-run" with a value of "true". A dry-run will abort the data-send process after validation end enryption of the transfer bundle but before the bundle is stored in the local DSF FHIR server and a Task to start the data-translate process is send to the GECCO Transfer Hub.

Closes #77 